### PR TITLE
Add asymmetric ZLE parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,7 @@ CFLAGS = -g -Wall -Iinc -std=c++11 -O2
 CPPFLAGS = $(CFLAGS)
 LDFLAGS = -lCAENDigitizer -lmongoclient -lsqlite3 -lpthread
 INSTALLDIR = /usr/local/bin
-INSTALL = cp $(EXE) $(INSTALLDIR)
 EXE = obelix
-CHMOD = chmod 0755
 
 sources := $(wildcard src/*.cpp)
 objects := $(sources:.cpp=.o)
@@ -17,7 +15,7 @@ exe : $(objects)
 	$(CC) $(CPPFLAGS) -o $(EXE) $(objects) $(LDFLAGS)
 
 install :
-	$(INSTALL)
+	$(CC) $(CPPFLAGS) -o $(INSTALLDIR)/$(EXE) $(objects) $(LDFLAGS)
 
 $(L)%.o : %.cpp %.h %.d
 	$(CC) $(CPPFLAGS) -c $< -o $@

--- a/config/ASTERIX.json
+++ b/config/ASTERIX.json
@@ -69,7 +69,8 @@
         "dc_offset" : 2792,
         "trigger_threshold" : 15800,
         "zle_threshold" : 15900,
-        "prepost_samples" : 5
+        "zle_lbk_samples" : 5,
+        "zle_lfwd_samples" : 25
         },
         {
         "board" : 0,
@@ -78,7 +79,8 @@
         "dc_offset" : 3800,
         "trigger_threshold" : 15800,
         "zle_threshold" : 15900,
-        "prepost_samples" : 5
+        "zle_lbk_samples" : 5,
+        "zle_lfwd_samples" : 25
         },
         {
         "board" : 0,
@@ -87,7 +89,8 @@
         "dc_offset" : 2700,
         "trigger_threshold" : 15800,
         "zle_threshold" : 15900,
-        "prepost_samples" : 5
+        "zle_lbk_samples" : 5,
+        "zle_lfwd_samples" : 25
         },
         {
         "board" : 0,
@@ -96,7 +99,8 @@
         "dc_offset" : 3724,
         "trigger_threshold" : 15750,
         "zle_threshold" : 15900,
-        "prepost_samples" : 5
+        "zle_lbk_samples" : 5,
+        "zle_lfwd_samples" : 25
         },
         {
         "board" : 0,
@@ -105,7 +109,8 @@
         "dc_offset" : 2800,
         "trigger_threshold" : 15800,
         "zle_threshold" : 15900,
-        "prepost_samples" : 5
+        "zle_lbk_samples" : 5,
+        "zle_lfwd_samples" : 25
         },
         {
         "board" : 0,
@@ -114,7 +119,8 @@
         "dc_offset" : 2800,
         "trigger_threshold" : 15800,
         "zle_threshold" : 15900,
-        "prepost_samples" : 5
+        "zle_lbk_samples" : 5,
+        "zle_lfwd_samples" : 25
         },
         {
         "board" : 0,
@@ -123,7 +129,8 @@
         "dc_offset" : 2800,
         "trigger_threshold" : 15800,
         "zle_threshold" : 15900,
-        "prepost_samples" : 5
+        "zle_lbk_samples" : 5,
+        "zle_lfwd_samples" : 25
         },
         {
         "board" : 0,
@@ -132,7 +139,8 @@
         "dc_offset" : 0,
         "trigger_threshold" : 0,
         "zle_threshold" : 0,
-        "prepost_samples" : 5
+        "zle_lbk_samples" : 5,
+        "zle_lfwd_samples" : 25
         }
     ],
     "registers" : [

--- a/config/LED.json
+++ b/config/LED.json
@@ -64,7 +64,8 @@
             "dc_offset" : 2792,
             "trigger_threshold" : 15000,
             "zle_threshold" : 15000,
-            "prepost_samples" : 10
+            "zle_lbk_samples" : 5,
+            "zle_lfwd_samples" : 25
         },
         {
             "board" : 0,
@@ -73,7 +74,8 @@
             "dc_offset" : 3800,
             "trigger_threshold" : 15000,
             "zle_threshold" : 15000,
-            "prepost_samples" : 10
+            "zle_lbk_samples" : 5,
+            "zle_lfwd_samples" : 25
         },
         {
             "board" : 0,
@@ -82,7 +84,8 @@
             "dc_offset" : 2700,
             "trigger_threshold" : 15000,
             "zle_threshold" : 15000,
-            "prepost_samples" : 10
+            "zle_lbk_samples" : 5,
+            "zle_lfwd_samples" : 25
         },
         {
             "board" : 0,
@@ -91,7 +94,8 @@
             "dc_offset" : 3724,
             "trigger_threshold" : 15000,
             "zle_threshold" : 15000,
-            "prepost_samples" : 10
+            "zle_lbk_samples" : 5,
+            "zle_lfwd_samples" : 25
         },
         {
             "board" : 0,
@@ -100,7 +104,8 @@
             "dc_offset" : 2870,
             "trigger_threshold" : 15000,
             "zle_threshold" : 15000,
-            "prepost_samples" : 10
+            "zle_lbk_samples" : 5,
+            "zle_lfwd_samples" : 25
         },
         {
             "board" : 0,
@@ -109,7 +114,8 @@
             "dc_offset" : 2870,
             "trigger_threshold" : 15000,
             "zle_threshold" : 15000,
-            "prepost_samples" : 10
+            "zle_lbk_samples" : 5,
+            "zle_lfwd_samples" : 25
         },
         {
             "board" : 0,
@@ -118,7 +124,8 @@
             "dc_offset" : 2870,
             "trigger_threshold" : 15000,
             "zle_threshold" : 15000,
-            "prepost_samples" : 10
+            "zle_lbk_samples" : 5,
+            "zle_lfwd_samples" : 25
         },
         {
             "board" : 0,
@@ -127,7 +134,8 @@
             "dc_offset" : 0,
             "trigger_threshold" : 0,
             "zle_threshold" : 0,
-            "prepost_samples" : 10
+            "zle_lbk_samples" : 5,
+            "zle_lfwd_samples" : 25
         }
     ],
     "registers" : []

--- a/inc/base.h
+++ b/inc/base.h
@@ -33,7 +33,8 @@ struct ChannelSettings_t {
     unsigned int DCoffset;
     unsigned int TriggerThreshold;
     unsigned int ZLEThreshold;
-    int PrePostSamples;
+    int ZLE_N_LFWD;
+    int ZLE_N_LBK;
     CAEN_DGTZ_TriggerMode_t TriggerMode;
 };
 

--- a/src/DAQ.cpp
+++ b/src/DAQ.cpp
@@ -152,12 +152,14 @@ void DAQ::Setup(const string& filename) {
     try {
         CS.EnableMask = 0;
         for (auto& cs : config_dict["channels"].Array()) {
-            ChanSet.Channel = cs["channel"].Int();
-            ChanSet.Enabled = cs["enabled"].Int();
-            ChanSet.DCoffset = cs["dc_offset"].Int();
-            ChanSet.TriggerThreshold = cs["trigger_threshold"].Int();
-            ChanSet.TriggerMode = CS.ChTriggerMode;
-            ChanSet.ZLEThreshold = cs["zle_threshold"].Int();
+            ChanSet.Channel             = cs["channel"].Int();
+            ChanSet.Enabled             = cs["enabled"].Int();
+            ChanSet.DCoffset            = cs["dc_offset"].Int();
+            ChanSet.TriggerThreshold    = cs["trigger_threshold"].Int();
+            ChanSet.TriggerMode         = CS.ChTriggerMode;
+            ChanSet.ZLEThreshold        = cs["zle_threshold"].Int();
+            ChanSet.ZLE_N_LFWD          = cs["zle_lfwd_samples"].Int();
+            ChanSet.ZLE_N_LBK           = cs["zle_lbk_samples"].Int();
             if (ChanSet.Enabled) CS.EnableMask |= (1 << ChanSet.Channel);
             CS.ChannelSettings.push_back(ChanSet);
             config.ChannelSettings.push_back(ChanSet);

--- a/src/Digitizer.cpp
+++ b/src/Digitizer.cpp
@@ -51,6 +51,7 @@ void Digitizer::StopAcquisition() {
 void Digitizer::ProgramDigitizer(ConfigSettings_t& CS) {
     CAEN_DGTZ_ErrorCode ret = CAEN_DGTZ_Success;
     unsigned int val(0), AllocSize(0);
+    unsigned int address(0), data(0);
 
     // start with reset
     ret = CAEN_DGTZ_Reset(m_iHandle);
@@ -103,10 +104,10 @@ void Digitizer::ProgramDigitizer(ConfigSettings_t& CS) {
         if (CS.IsZLE) {
             ret = CAEN_DGTZ_SetZeroSuppressionMode(m_iHandle, CAEN_DGTZ_ZS_ZLE);
             if (ret != CAEN_DGTZ_Success) cout << "Board " << m_iHandle << ": Error setting channel " << ch_set.Channel << " ZLE mode: " << ret << "\n";
-            ret = CAEN_DGTZ_SetChannelZSParams(m_iHandle, ch_set.Channel, CAEN_DGTZ_ZS_FINE, ch_set.ZLEThreshold, ch_set.PrePostSamples);
-        /*  ret = WriteRegister(GW_t{CAEN_DGTZ_CHANNEL_ZS_THRESHOLD_BASE_ADDRESS + (0x100 * ch_set.Channel),
-                                    (1 << 31) + ch_set.ZLEThreshold,
-                                    THRESHOLD_MASK}); */
+            ret = CAEN_DGTZ_SetChannelZSParams(m_iHandle, ch_set.Channel, CAEN_DGTZ_ZS_FINE, ch_set.ZLEThreshold, 0);
+            address = CAEN_DGTZ_SAM_REG_VALUE + (0x100 * ch_set.Channel);
+            data = (ch_set.ZLE_N_LBK << 16) + ch_set.ZLE_N_LFWD;
+            ret = WriteRegister(GW_t{address, data, 0xFFFFFFFF});
             if (ret != CAEN_DGTZ_Success) cout << "Board " << m_iHandle << ": Error setting channel " << ch_set.Channel << " ZLE parameters: " << ret << "\n";
         }
     }


### PR DESCRIPTION
Adds the option to ZLE encode different numbers of samples before and after the threshold-crossing.